### PR TITLE
Use nproc instead of cpuinfo

### DIFF
--- a/bin/postqueue-checker
+++ b/bin/postqueue-checker
@@ -1,0 +1,9 @@
+#!/bin/dash
+
+while true; do
+   sleep 600
+
+   postqueue-notify
+done
+
+# vim: ft=sh

--- a/bin/postqueue-notify
+++ b/bin/postqueue-notify
@@ -1,0 +1,8 @@
+#!/bin/dash
+
+old_count="$(postqueue -j | jq 'now - .arrival_time > 300' | grep true | wc -l)"
+
+if [ "$old_count" -gt 0 ]; then
+   notify-send -u critical "$old_count emails stuck in queue"
+fi
+# vim: ft=sh

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ for x in           \
    link-file $x ~/.$x
 done
 
-echo "[submodule]\n\tfetchJobs = $(cat /proc/cpuinfo | grep '^processor' | wc -l)\n\n" > ~/.git-multicore
+echo "[submodule]\n\tfetchJobs = $(nproc)\n\n" > ~/.git-multicore
 
 # ensure submodules are checked out before linking to them
 git submodule update --init

--- a/xsession
+++ b/xsession
@@ -10,6 +10,7 @@ sv-run-w.pl &
 sv-run-offlineimap &
 scenery &
 armstrong &
+postqueue-checker &
 
 exec awesome
 # vim: ft=sh


### PR DESCRIPTION
Just read your recent [article](https://blog.afoolishmanifesto.com/posts/my-mobile-shell-home), and thought you might be interested in simplifying `cat /proc/cpuinfo | grep '^processor' | wc -l` into `nproc`.